### PR TITLE
Abm attack fraction/likelihood update

### DIFF
--- a/benchmarks/abm-attack-fraction/README.md
+++ b/benchmarks/abm-attack-fraction/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-In this benchmark we run [EMOD](https://docs.idmod.org/projects/emod-generic/en/latest/index.html), a stochastic agent based disease transmission model, to look at how the reproductive number, [$R_0$](https://en.wikipedia.org/wiki/Basic_reproduction_number), and the correlation between an individual's acquisition and transmission correlation can affect the ultimate attack fraction. It turns out that this correlation can greatly affect that size of the outbreak for a fixed reproductive number. 
+In this benchmark we run [EMOD](https://docs.idmod.org/projects/emod-generic/en/latest/index.html), a stochastic agent based disease transmission model, to look at how the reproductive number, [$R_0$](https://en.wikipedia.org/wiki/Basic_reproduction_number), and the correlation between an individual's acquisition and transmission correlation can affect the ultimate attack fraction and timing of the outbreak peak. It turns out that this correlation can affect that size and timing of the outbreak for a fixed reproductive number. 
 
 
 ## Authors
@@ -58,7 +58,7 @@ $ \sigma_{I_t} = \log\left(\frac{\sigma_{R_0}^2}{2R_0^2} + 0.5\right). $
 
 One of the challenges associated with this benchmark is that it is stochastic.  Even for the same parameters the total number of infections will differ between simulations. Furthermore, it is not guaranteed that there will always be an outbreak: sometimes, by chance, there are not enough initial infections to generate a large outbreak.  You can reduce this challenge by increasing the number of initial infections via the `daily_import_pressures` configuration parameter (e.g., from 1 infections per day to 10 infections per day for the first 5 days).
 
-Furthermore, the likelihood of an individual to acquire and then transmit the disease is correlated. There is no waning immunity. The benchmark is fitting to an attack fraction of 0.40 with a standard deviation of 0.025. There are bounds on $R_0$ > 0; the variance of $R_0$ > 0; and the correlation between acquisition and transmission must lie between 0 and 1 (inclusive).
+Furthermore, the likelihood of an individual to acquire and then transmit the disease is correlated. There is no waning immunity. The benchmark is fitting to an attack fraction of 0.40 with a standard deviation of 0.05 and an outbreak peak at 175 days from the start of the simulation with standard deviation of 10 days. There are bounds on $R_0$ > 0; the variance of $R_0$ > 0; and the correlation between acquisition and transmission must lie between 0 and 1 (inclusive).
 
 The simulation terminates when there are no longer any infected individuals (minimum run time of 50 days) and assesses the final attack fraction in the population (the fraction of people who were infected over the course of the disease outbreak).
 

--- a/benchmarks/abm-attack-fraction/server.py
+++ b/benchmarks/abm-attack-fraction/server.py
@@ -36,9 +36,9 @@ class EMODBenchmarkModel(umbridge.Model):
             return [[-1e60]]
 
         # likelihood definition
-        data = [0.4]
-        likelihood_std_dev = [0.025]
-        likelihood_cov_matrix_diag = [likelihood_std_dev[0]**2]
+        data = [0.4, 175]
+        likelihood_std_dev = [0.05, 10]
+        likelihood_cov_matrix_diag = [likelihood_std_dev[0]**2, likelihood_std_dev[1]**2]
 
         posterior = scipy.stats.multivariate_normal.logpdf(model_output, data, likelihood_cov_matrix_diag)
 


### PR DESCRIPTION
I have added an additional component to the abm-attack-fraction benchmark. In addition to the outbreak size we now are also constrained to the timing of the outbreak (measured by its peak). This adds correlation between the reproductive number and individual acquisition/transmission correlation. This pull request reflects updates to the README and server.py. The manuscript has also been updated to reflect these changes.