### PR TITLE
Remove dependency on physical_dim parameter in GMRF for CUQI CT

### DIFF
--- a/benchmarks/cuqi-ct/server.py
+++ b/benchmarks/cuqi-ct/server.py
@@ -127,7 +127,6 @@ class CT_GMRF(CT_UM):
         super().__init__(self.__class__.__name__)
         self.prior = GMRF(np.zeros(self.dim), 
                           lambda delta: 1 / delta,
-                          physical_dim=2,
                           geometry=self.likelihood.geometry,
                           name="x")
 

--- a/benchmarks/cuqi-ct/server.py
+++ b/benchmarks/cuqi-ct/server.py
@@ -44,16 +44,21 @@ class CT_UM(umbridge.Model):
 
         Amat = dx*Amat
 
+        # Create Image2D geometries of image and sinogram spaces
+        dg = Image2D(( N,N))
+        rg = Image2D((nv,N))
+
+        # Define forward and adjoint operators (working on images)
+        def forward(x):
+            y = Amat @ x.ravel()
+            return y.reshape((nv, N))
+
+        def adjoint(y):
+            x = Amat.T @ y.ravel()
+            return x.reshape((N, N))
+
         # Create the CUQIpy linear model
-        A = LinearModel(Amat)
-
-        # Create the visual_only Image2D geometries of image and sinogram spaces
-        dg = Image2D(( N,N), visual_only=True)
-        rg = Image2D((nv,N), visual_only=True)
-
-        # Equip linear operator with geometries
-        A.domain_geometry = dg
-        A.range_geometry = rg
+        A = LinearModel(forward=forward, adjoint=adjoint, range_geometry=rg, domain_geometry=dg)
 
         # Create the CUQI data structure from vectorized image and geometry
         imC = CUQIarray(data["exact"], geometry=dg)

--- a/benchmarks/cuqi-ct/test_output.py
+++ b/benchmarks/cuqi-ct/test_output.py
@@ -132,7 +132,6 @@ BP.prior = cuqi.distribution.Gaussian(np.zeros(256**2), 0.01,
 assert output_Gaussian == pytest.approx(BP.posterior.logpdf(parameters))
 
 BP.prior = cuqi.distribution.GMRF(np.zeros(256**2), 1/(0.01),
-                                  physical_dim=2,
                                   geometry=BP.likelihood.geometry)
 assert output_GMRF == pytest.approx(BP.posterior.logpdf(parameters))
 

--- a/benchmarks/cuqi-ct/test_output.py
+++ b/benchmarks/cuqi-ct/test_output.py
@@ -41,12 +41,21 @@ dx = width/N
 
 Amat = dx*Amat
 
-# Create the CUQIpy linear model
-A = LinearModel(Amat)
+# Create Image2D geometries of image and sinogram spaces
+dg = Image2D(( N,N))
+rg = Image2D((nv,N))
 
-# Create the visual_only Image2D geometries of image and sinogram spaces
-dg = Image2D(( N,N), visual_only=True)
-rg = Image2D((nv,N), visual_only=True)
+# Define forward and adjoint operators (working on images)
+def forward(x):
+    y = Amat @ x.ravel()
+    return y.reshape((nv, N))
+
+def adjoint(y):
+    x = Amat.T @ y.ravel()
+    return x.reshape((N, N))
+
+# Create the CUQIpy linear model
+A = LinearModel(forward=forward, adjoint=adjoint, range_geometry=rg, domain_geometry=dg)
 
 # Equip linear operator with geometries
 A.domain_geometry = dg


### PR DESCRIPTION
After recent update in CUQIpy (0.8.0->1.0.0), the parameter `physical_dim` is no longer needed in GMRF if the geometry is passed to distribution. To handle this properly it was neccecary to use actual Image2D geometries and not the "visual_only" version. This was achieved by defining the LinearModel more explicitly.