### PR TITLE
emod-abm: match return value for out of bounds to regular execution

### DIFF
--- a/models/emod-abm/model.py
+++ b/models/emod-abm/model.py
@@ -57,7 +57,10 @@ class EMODForwardModel(umbridge.Model):
         if (R0_VAR <= 0) or (R0 <= 0) or  \
             (Acquisition_Transmission_Correlation > 1) or \
                 (Acquisition_Transmission_Correlation < 0):
-            return [[-999]]
+            channels = ['New Infections', 'Infected', 'Infectious Population', 'Susceptible Population', 'Symptomatic Population', 'Recovered Population', 'Exposed Population']
+            values = [0, 0, 0, 1, 0, 0, 0]
+            out_of_bounds = {k:{"Data":[v]} for k,v in zip(channels, values)}
+            return [[out_of_bounds]]
 
         # update config file
         inf_prd_mean   = 8.0


### PR DESCRIPTION
This pull request changes the out of bounds return falue of the emod-abm model to match for format (dict of dicts) of the regular model.