### PR TITLE
Update Dockerfile for GS2 model

### DIFF
--- a/models/gs2/Dockerfile
+++ b/models/gs2/Dockerfile
@@ -36,7 +36,7 @@ RUN echo 'alias pip=pip3' >> $HOME/.bashrc
 
 RUN echo 'export GK_SYSTEM=gnu_ubuntu' >> $HOME/.bashrc
 
-RUN git clone https://whornsby@bitbucket.org/gyrokinetics/gs2.git /usr/gs2
+RUN git clone --recurse-submodules https://bitbucket.org/gyrokinetics/gs2.git /usr/gs2
 
 WORKDIR /usr/gs2
 
@@ -46,13 +46,11 @@ ENV GK_SYSTEM=gnu_ubuntu
 
 RUN echo ${GK_SYSTEM}
 
-RUN make -IMakefiles depend
-
 RUN make -IMakefiles gs2
 #RUN make -IMakefiles tests
 
 RUN python -m venv venv && . venv/bin/activate && \
-    pip install ford netCDF4==1.6.2 umbridge pyrokinetics 
+    pip install umbridge pyrokinetics 
 
 COPY server.py fast.in .
 


### PR DESCRIPTION
CI fails for GS2 because it was not cloning recursively.