### PR TITLE
Update exahype and gs2 models

### DIFF
--- a/models/exahype-tsunami/Dockerfile
+++ b/models/exahype-tsunami/Dockerfile
@@ -1,6 +1,8 @@
-FROM chun9l/openmpi-builder:0.3.0 as builder
+FROM mpioperator/openmpi-builder:0.3.0 as builder
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list
 
 RUN apt-get update && \
     apt-get install -y python3 git cmake wget curl zlib1g pkg-config libhdf5-openmpi-dev libc6-dev libnuma-dev doxygen libyaml-cpp-dev gfortran libtbb-dev libstdc++-8-dev liblua5.3-dev
@@ -21,7 +23,7 @@ ENV PKG_CONFIG_PATH="/dependencies/ImpalaJIT/build/:/dependencies/netcf-c-4.8.1/
 ENV CMAKE_PREFIX_PATH=/dependencies/netcdf-c-4.8.1/lib/
 
 RUN cd /dependencies && git clone --recursive https://github.com/TUM-I5/ASAGI.git && \
-    cd ASAGI/ && \
+    cd ASAGI/ && git checkout 51f9c93 && \
     mkdir build && cd build && \
     NetCDF_LIBRARY=/dependencies/netcdf-c-4.8.1/lib cmake -DMPI_C_COMPILER=mpicc -DMPI_CXX_COMPILER=mpicxx -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
                -DTHREADSAFE=ON -DNONUMA=ON -DSHARED_LIB=1 -DCMAKE_CXX_FLAGS="-I/dependencies/netcdf-c-4.8.1/include/" ..  && \
@@ -31,7 +33,7 @@ ENV COMPILER_LFLAGS=" -L/dependencies/ImpalaJIT/build/ -limpalajit -L/dependenci
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"/usr/local/lib/:/dependencies/ImpalaJIT/build"
 
 RUN cd /dependencies/ && git clone https://github.com/SeisSol/easi.git && \
-    cd easi && git checkout 647ff0863a83c011e56c8eb6b4fc522fa355c153 &&\
+    cd easi && git checkout 647ff0863a83c011e56c8eb6b4fc522fa355c153 && \
     mkdir build && cd build && \
     CC=mpicc CXX=mpicxx cmake -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=TRUE -DCMAKE_PREFIX_PATH=/dependencies/ -DCMAKE_INSTALL_PREFIX=/dependencies/easi/build/ .. && \
     make -j4
@@ -74,6 +76,8 @@ RUN cd /server && \
 FROM mpioperator/openmpi:0.3.0
 
 SHELL ["/bin/bash", "-c"]
+
+RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list
 
 RUN apt-get update && \
     apt-get install -y python3 libyaml-cpp0.6 libtbb2 libhdf5-openmpi-103 liblua5.3-dev && \

--- a/models/gs2/fast.in
+++ b/models/gs2/fast.in
@@ -3,24 +3,24 @@
 /
 
 &kt_grids_single_parameters
-    aky = 0.7852773972394589
+    aky = 0.3627
     theta0 = 0.0
 /
 
 &theta_grid_parameters
-    ntheta = 128
-    nperiod = 9
     akappa = 2.66
     akappri = -0.25
-    rhoc = 0.67
-    tri = 0.3400000000000001
-    tripri = 0.25
-    shat = 0.87
-    qinp = 8.903370045724728
-    r_geo = 1.84
-    rmaj = 1.84
-    shift = -0.44
     geotype = 0
+    nperiod = 9
+    ntheta = 128
+    qinp = 2.2857142857142856
+    r_geo = 1.84
+    rhoc = 0.67
+    rmaj = 1.84
+    shat = 0.87
+    shift = -0.44
+    tri = 0.3400000000000002
+    tripri = 0.25
 /
 
 &theta_grid_knobs
@@ -28,27 +28,27 @@
 /
 
 &theta_grid_eik_knobs
-    irho = 2
-    iflux = 0
-    s_hat_input = 3.1173933836235315
     beta_prime_input = -0.64
-    local_eq = .true.
     bishop = 4
     equal_arc = .false.
+    iflux = 0
+    irho = 2
+    local_eq = .true.
+    s_hat_input = 3.70858
     writelots = .true.
 /
 
 &le_grids_knobs
-    ngauss = 8
-    negrid = 16
     bouncefuzz = 1e-08
+    negrid = 16
+    ngauss = 8
 /
 
 &dist_fn_knobs
     adiabatic_option = 'iphi00=2'
-    opt_source = .true.
     def_parity = .true.
     even = .false.
+    opt_source = .true.
 /
 
 &fields_knobs
@@ -57,12 +57,15 @@
 /
 
 &knobs
-    fphi = 1.0
+    beta = 0.1417
+    delt = 0.02
     fapar = 1.0
     fbpar = 0.0
-    delt = 0.02
+    fphi = 1.0
     nstep = 80000
+    tite = 1.0
     wstar_units = .true.
+    zeff = 1.0
 /
 
 &layouts_knobs
@@ -78,93 +81,85 @@
 /
 
 &species_parameters_1
-    z = 1.0
-    mass = 1.0
+    bess_fac = 1.0
     dens = 0.5
+    fprim = 0.5206524475
+    mass = 1.0
     temp = 1.0593220338983051
     tprim = 0.0
-    fprim = 0.1450502618121151
+    type = 'ion'
     uprim = 0.0
     vnewk = 0.00039999999999999996
-    type = 'ion'
-    bess_fac = 1.0
+    z = 1.0
 /
 
 &dist_fn_species_knobs_1
-    fexpr = 0.48
     bakdif = 0.05
+    fexpr = 0.48
 /
 
 &species_parameters_2
-    z = 1.0
-    mass = 1.4975
+    bess_fac = 1.0
     dens = 0.5
+    fprim = 0.5206524475
+    mass = 1.4975
     temp = 1.0593220338983051
     tprim = 0.0
-    fprim = 0.1450502618121151
+    type = 'ion'
     uprim = 0.0
     vnewk = 0.0003268711385781747
-    type = 'ion'
-    bess_fac = 1.0
+    z = 1.0
 /
 
 &dist_fn_species_knobs_2
-    fexpr = 0.48
     bakdif = 0.05
+    fexpr = 0.48
 /
 
 &species_parameters_3
-    z = -1
-    mass = 0.0002724
-    dens = 1.0
-    temp = 1.0
-    tprim = 4.98536245337014
-    fprim = 2.0329154559480602
-    uprim = 0.0
-    vnewk = 0.011195269013375201
-    type = 'electron'
     bess_fac = 1.0
+    dens = 1.0
+    fprim = 2.4592
+    mass = 0.0002724
+    temp = 1.0
+    tprim = 3.2343
+    type = 'electron'
+    uprim = 0.0
+    vnewk = 0.0469
+    z = -1
 /
 
 &dist_fn_species_knobs_3
-    fexpr = 0.48
     bakdif = 0.05
+    fexpr = 0.48
 /
 
 &init_g_knobs
-    ginit_option = 'default_odd'
     chop_side = .false.
+    ginit_option = 'default_odd'
     phiinit = 1e-05
     restart_dir = 'restart'
 /
 
 &gs2_diagnostics_knobs
-    write_ascii = .true.
-    write_omega = .true.
-    write_final_fields = .true.
-    write_fields = .true.
-    write_phi_over_time = .true.
-    write_bpar_over_time = .true.
-    write_apar_over_time = .true.
-    write_nl_flux_dist = .true.
-    write_fluxes = .true.
-    write_nl_flux = .true.
-    nwrite = 30
     navg = 10
-    omegatol = 0.0001
-    omegatinst = 500.0
     nsave = 5000
-    save_for_restart = .true.
+    nwrite = 30
+    omegatinst = 500.0
+    omegatol = 0.0001
+    save_for_restart = .false.
+    write_apar_over_time = .true.
+    write_ascii = .true.
+    write_bpar_over_time = .true.
+    write_fields = .true.
     write_final_epar = .true.
-/
-
-&parameters
-    beta = 0.29798123734456977
-    tite = 1.0
-    zeff = 1.0
+    write_final_fields = .true.
+    write_fluxes = .true.
+    write_nl_flux_dist = .true.
+    write_omega = .true.
+    write_phi_over_time = .true.
 /
 
 &diagnostics_config
     nwrite = 100000000
 /
-


### PR DESCRIPTION
Exahype fails because Debian buster source list has been archived.

GS2 fails because input file is outdated