### PR TITLE
Fix EMOD ABM evaluate JSON encoding

### DIFF
--- a/benchmarks/abm-attack-fraction/server.py
+++ b/benchmarks/abm-attack-fraction/server.py
@@ -27,7 +27,8 @@ class EMODBenchmarkModel(umbridge.Model):
         # returns attack fraction of the model ([0,1]), -0 for out of bounds
         model_output = self.model(parameters, config)[0]
 
-        model_output = [1 - model_output[0]['Susceptible Population']['Data'][-1] ]
+        result = json.loads(model_output[0])
+        model_output = [1 - result['Susceptible Population']['Data'][-1]]
 
         print(model_output)
 

--- a/models/emod-abm/model.py
+++ b/models/emod-abm/model.py
@@ -60,7 +60,7 @@ class EMODForwardModel(umbridge.Model):
             channels = ['New Infections', 'Infected', 'Infectious Population', 'Susceptible Population', 'Symptomatic Population', 'Recovered Population', 'Exposed Population']
             values = [0, 0, 0, 1, 0, 0, 0]
             out_of_bounds = {k:{"Data":[v]} for k,v in zip(channels, values)}
-            return [[out_of_bounds]]
+            return [[json.dumps(out_of_bounds)]]
 
         # update config file
         inf_prd_mean   = 8.0
@@ -97,7 +97,8 @@ class EMODForwardModel(umbridge.Model):
         # remove extra files
         self._cleanup()
 
-        return [[{float(c):inset_chart['Channels'][c] for c in ['New Infections', 'Infected', 'Infectious Population', 'Susceptible Population', 'Symptomatic Population', 'Recovered Population', 'Exposed Population']}]]
+        result = {c: inset_chart['Channels'][c] for c in ['New Infections', 'Infected', 'Infectious Population', 'Susceptible Population', 'Symptomatic Population', 'Recovered Population', 'Exposed Population']}
+        return [[json.dumps(result)]]
 
     def supports_evaluate(self):
         return True    


### PR DESCRIPTION
## Summary
- return EMOD ABM model channel data as JSON strings from the model
- parse the serialized result in the benchmark server before computing the attack fraction
- preserve the out-of-bounds fallback in the same serialized format

Fixes #116